### PR TITLE
added docker build to workflow

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64,arm
+        
       - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@v1
         

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
           push: true
           tags: |
             ${{secrets.DOCKER_USER}}/ts3-manager:${{ github.event.release.tag_name }}

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/armv7
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6
           push: true
           tags: |
             ${{secrets.DOCKER_USER}}/ts3-manager:${{ github.event.release.tag_name }}

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -43,3 +43,33 @@ jobs:
           asset_name: ${{ matrix.file-name }}
           tag: ${{ github.ref }}
           overwrite: true
+          
+  publish-docker:
+    name: Publish Docker images
+    runs-on: ubuntu-latest
+   
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v1
+        
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/armv7
+          push: true
+          tags: |
+            ${{secrets.DOCKER_USER}}/ts3-manager:${{ github.event.release.tag_name }}
+            ${{secrets.DOCKER_USER}}/ts3-manager:latest
+          
+          
+          


### PR DESCRIPTION
Hey joni1802,

we wanted to build a raspberry pi image for us and automatically push it to the dockerhub registry.
So we extended your build workflow to include a multi platform docker build. We are not sure how and where the current one's are generated, but we hope you could use this addition.

For the workflow to work, you need to define two new secrets.

- DOCKER_USER: <docker_user>
- DOCKER_TOKEN: <docker_access_token>

best regards
cp-fabian-pittroff & MrRightInHD