### PR TITLE
Fixed display of spacers containing square brackets

### DIFF
--- a/packages/ui/src/components/Spacer.vue
+++ b/packages/ui/src/components/Spacer.vue
@@ -34,7 +34,7 @@ export default {
       let disassembledSpacer = name.match(this.spacer);
       let alignment = disassembledSpacer[1];
 
-      this.text = disassembledSpacer[4];
+      this.text = name.split(/](.*)/s)[1];
 
       if (this.characterBlocks.includes(this.text)) {
         this.specialSpacer = true;


### PR DESCRIPTION
Hey,

I really enjoy using the ts3-manager to manage my teamspeak servers. 

However, it has always bugged me that my AFK Channel isn't properly displayed because its name contains square brackets and it is configured as a spacer ("[cspacer]"). 

I managed to fix it with a small adjustment in how the text of a spacer is generated. Now, using a regular expression, it just uses all text after the first occurrence of a closing square bracket. Here are the results:

Before:
![image](https://user-images.githubusercontent.com/44505808/222192215-546d4a2d-a336-4345-942b-f1719ee57fb2.png)

After:
![image](https://user-images.githubusercontent.com/44505808/222192352-6547ce7e-0e52-4ed1-a4c5-71fdd2a98bfe.png)

I hope you find this contribution useful. Thanks for the work!

Best regards
Uggah